### PR TITLE
FreeBSD patches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ add_definitions(-D'DOCUMENT_PATH="${CMAKE_INSTALL_PREFIX}/share/doc"')
 include(CheckCSourceCompiles)
 include(CheckCXXCompilerFlag)
 
+
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    link_directories(/usr/local/lib)
+endif()
+
 check_cxx_compiler_flag("-msse2" SUPPORT_SSE)
 
 option (BuildForDebug "Include gdb debugging support" OFF)

--- a/timeline/src/Audio_Sequence.C
+++ b/timeline/src/Audio_Sequence.C
@@ -27,6 +27,9 @@
 #include "../../nonlib/debug.h"
 
 #include <sys/time.h>
+#ifndef __linux__
+#include <libgen.h>
+#endif
 #include <FL/fl_ask.H>
 #include <FL/Fl.H>
 

--- a/timeline/src/Engine/Peaks.C
+++ b/timeline/src/Engine/Peaks.C
@@ -116,7 +116,7 @@ class Peakfile
         }
 
         bool
-        operator< ( const block_descriptor &rhs )
+        operator< ( const block_descriptor &rhs ) const
         {
             return chunksize < rhs.chunksize;
         }


### PR DESCRIPTION
Reapplied to WIP

Fixes:
- std::list::sort needing const for both arguments
- ligen.h being needed for basename
- CMake link directories for FreeBSD

Thank you! :)